### PR TITLE
fix: insert code at the current cursor position

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,8 @@ export function activate(context: vscode.ExtensionContext) {
 
           // Paste.
           vscode.window.activeTextEditor?.edit((editBuilder) => {
-            editBuilder.insert(new vscode.Position(0, 0), phpArrayValue);
+            const position = r.window.activeTextEditor.selection?.active || new r.Position(0,0);
+            editBuilder.insert(position, phpArrayValue);
           });
         } catch (error) {
           // Show error message.


### PR DESCRIPTION
I never worked on a VSCode extensions before so feel free to judge if I'm doing something wrong, but I tried this on my end and it fixed the issue I just reported (#1).

With this change, the data is pasted at the cursor's current position:


https://user-images.githubusercontent.com/9383532/219902288-f997c90b-cad7-4d47-9cf7-0c556377ad77.mp4

The indentation is off, but this still feels like a major improvement to me.

---

closes #1