### PR TITLE
fix: improve conversion to avoid broken string values

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,0 +1,30 @@
+export function convertJsonToPhpArray(json: string) {
+  let php = '';
+  let isInsideString = false;
+  let previousChar = null;
+
+  for (let char of e.split('')) {
+    if (char == '"' && previousChar !== '\\') {
+      isInsideString = !isInsideString;
+    }
+
+    if (!isInsideString) {
+      if (char == ':') {
+        char = '=>';
+
+        if (!/\s/.test(previousChar)) {
+          char = ' ' + char;
+        }
+      } else if (char == '{') {
+        char = '[';
+      } else if (char == '}') {
+        char = ']';
+      }
+    }
+
+    php += char;
+    previousChar = char;
+  }
+
+  return php;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { convertJsonToPhpArray } from "./convert.ts";
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
@@ -10,10 +11,7 @@ export function activate(context: vscode.ExtensionContext) {
           JSON.parse(jsonValue);
 
           // Convert to PHP Array.
-          const phpArrayValue = jsonValue
-            .replaceAll("{", "[")
-            .replaceAll("}", "]")
-            .replaceAll(":", " =>");
+          const phpArrayValue = convertJsonToPhpArray(jsonValue);
 
           // Paste.
           vscode.window.activeTextEditor?.edit((editBuilder) => {


### PR DESCRIPTION
Hey there, me again!

Here's a pull request to fix the issue I mentioned in #3.

There's probably a much more clever and/or efficient way to go about it, but this is the first thing that came to mind and it ended up working so I figured it would be worth sharing.

Here's a before & after:

## Before
Notice the `=>` inside the URL and datetime strings.

https://user-images.githubusercontent.com/9383532/219909995-569fea4d-c1ef-4c4e-afa2-92ad975af2fc.mp4  


## After
No more broken values :)


https://user-images.githubusercontent.com/9383532/219910063-efc8e07c-f3ee-4dcc-b901-be334fc9484b.mp4


---

Closes #3 